### PR TITLE
Bump mccode-antlr version and fix API change

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,7 @@ name = "moreniius"
 dependencies = [
     'zenlog>=1.1',
     'platformdirs>=3.11',
-    "importlib_metadata; python_version<'3.8'",
-    'mccode-antlr[hdf5]>=0.9.2',
+    'mccode-antlr[hdf5]>=0.13.0',
     'nexusformat>=1.0.6'
 ]
 readme = "README.md"
@@ -17,7 +16,14 @@ authors = [
 ]
 classifiers = [
     "License :: OSI Approved :: BSD License",
-    "Development Status :: 2 - Pre-Alpha"
+    "Development Status :: 2 - Pre-Alpha",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 dynamic = ["version"]
 
@@ -31,6 +37,7 @@ legacy_tox_ini = """
     [tox]
     min_version = 4.0
     env_list =
+        py313
         py312
         py311
         py310
@@ -40,7 +47,7 @@ legacy_tox_ini = """
     [testenv]
     deps =
         pytest
-        git+https://github.com/g5t/mccode-to-kafka.git
+        mccode-to-kafka
     commands = pytest tests
 
     [testenv:type]

--- a/src/moreniius/mccode/instance.py
+++ b/src/moreniius/mccode/instance.py
@@ -150,7 +150,7 @@ def register_translator(name, translator):
     Your translator must be a function with one input, the NXInstance object, and one output, a NeXus object.
     After you have defined your translator function, you can register it with this function.
 
-    >>> import eniius
+    >>> import moreniius
     >>>
     >>> def my_translator(instance):
     >>>     from nexusformat.nexus import NXguide

--- a/src/moreniius/mccode/instr.py
+++ b/src/moreniius/mccode/instr.py
@@ -14,13 +14,13 @@ class NXInstr:
     def __post_init__(self):
         """Start the C translation to ensure McCode-oddities are handled before any C-code parsing."""
         from mccode_antlr.common import ShapeType, DataType, Value
-        from mccode_antlr.translators.target import MCSTAS_GENERATOR
+        from mccode_antlr import Flavor
         from mccode_antlr.translators.c import CTargetVisitor
         from mccode_antlr.translators.c_listener import CDeclarator
         from mccode_antlr.translators.c_listener import evaluate_c_defined_expressions
         config = dict(default_main=True, enable_trace=False, portable=False, include_runtime=True,
                       embed_instrument_file=False, verbose=False, output=None)
-        translator = CTargetVisitor(self.instr, generate=MCSTAS_GENERATOR, config=config)
+        translator = CTargetVisitor(self.instr, flavor=Flavor.MCSTAS, config=config)
         # translator.instrument_uservars is a list of `CDeclaration` objects, which are named tuples with
         # fields: name type init is_pointer is_array orig
         # translator.component_uservars is a dictionary of lists for each component type of `CDeclaration` objects.


### PR DESCRIPTION
## Bump `mccode-antlr`
New version `v0.13.0` does away with 'generator' dictionaries in favor of a `mccode_antlr.Flavor` enumerated value.
This required a small change in how the `CTargetVisitor` is instantiated.

## Other changes
- Python `v3.8` is  past EOL, so the special dependency for it can be dropped. 
- Added supported Python versions classifiers, covering 3.9 to 3.13
- `tox` tests can use the PyPI `mccode-to-antlr` instead of pulling from the source repository
- an in-comment use example loaded the wrong module name