### PR TITLE
Enhance positioning and orientation with improved messages and inverse ops

### DIFF
--- a/src/moreniius/mccode/instr.py
+++ b/src/moreniius/mccode/instr.py
@@ -111,84 +111,62 @@ class NXInstr:
         """Return the other end of edges starting at the named node"""
         return list(self.forward_graph[name])
 
+    def resolve_target(self, rel):
+        target = f'/entry/instrument/{rel.name}'
+        if (depends_on := self.nx.get(rel.name)) is None:
+            raise RuntimeError('transformations defined out of order')
+        if (t := depends_on.get('depends_on')) is None:
+            return None
+        if isinstance(t, NXfield):
+            t = str(t)
+        if t.startswith('/'):
+            return t
+        return None if t == '.' else f'{target}/{t}'
+
     def make_transformations(self, inst: Instance):
         from mccode_antlr.instr.orientation import Vector, Angles, Parts
         from .orientation import NXOrient, NXParts
 
-        def abs_ref(ref):
-            return f'/entry/instrument/{ref}'
-
-        def last_ref(refs: list[tuple[str, NXfield]]) -> str | None:
+        def last_ref(refs: list[tuple[str, NXfield]], default: str) -> str:
             try:
                 return next(reversed(refs))[0]
             except StopIteration:
-                pass
+                return default
+
 
         at_vec, at_rel = inst.at_relative
         rot_vec, rot_rel = inst.rotate_relative
 
-        any_abs = at_rel is None or rot_rel is None
-        nx_ori = NXOrient(self, inst.orientation - self.origin) if any_abs else None
-        if at_rel is None and rot_rel is None:
-            return nx_ori.transformations(inst.name)
-
         trans = []
-        if any_abs or at_rel != rot_rel:
-            import warnings
-            warnings.warn(
-                "All mixed-reference-type orientations untested. "
-                "Only 'AT (x, y, z) ABSOLUTE ROTATED (a, b, c) REF' might work\n"
-            )
         at_vec = Vector(*at_vec) if isinstance(at_vec, tuple) else at_vec
         rot_vec = Angles(*rot_vec) if isinstance(rot_vec, tuple) else rot_vec
         if at_rel is None:
-            # Absolute position with relative rotation
-            trans.extend(nx_ori.position_transformations(inst.name))
-            # Get the _rotation_ of the reference to add here before any new rotation
+            nx_ori = NXOrient(self, inst.orientation - self.origin)
+            if rot_rel is None:
+                return nx_ori.transformations(inst.name)
+            target = self.resolve_target(rot_rel)
+            trans.extend(nx_ori.position_transformations(inst.name, target))
             rel_ori = NXOrient(self, rot_rel.orientation - self.origin)
-            trans.extend(rel_ori.rotation_transformations(rot_rel.name, last_ref(trans)))
-            # Add the relative rotation onto the reference rotation
+            trans.extend(rel_ori.rotation_transformations(rot_rel.name, last_ref(trans, target)))
             rot = Parts(Parts.from_at_rotated(Vector(), rot_vec, True).stack()).reduce()
             nx_parts = NXParts(self, rot, rot)
-            trans.extend(nx_parts.rotation_transformations(inst.name, last_ref(trans)))
-        elif rot_rel is None:
-            at_name = at_rel.name if isinstance(at_rel, Instance) else at_rel
-            raise RuntimeError(
-                f"'COMPONENT {inst.name} ... AT {at_vec} RELATIVE {at_name} ROTATED {rot_vec} ABSOLUTE'"
-                " not yet implemented"
-            )
-        elif at_rel != rot_rel:
-            at_name = at_rel.name if isinstance(at_rel, Instance) else at_rel
-            rot_name = rot_rel.name if isinstance(rot_rel, Instance) else rot_rel
-            raise RuntimeError(
-                f"'COMPONENT {inst.name} ... AT {at_vec} RELATIVE {at_name} ROTATED {rot_vec} RELATIVE {rot_name}'"
-                " not yet implemented"
-            )
+            trans.extend(nx_parts.rotation_transformations(inst.name, last_ref(trans, target)))
         else:
+            target = self.resolve_target(at_rel)
             at_parts = Parts.from_at_rotated(at_vec, Angles(), True)
             rot_parts = Parts.from_at_rotated(Vector(), rot_vec, True)
             nx_parts = NXParts(self, at_parts, rot_parts)
-            # TODO replace the absolute reference to the component by an
-            #      absolute reference to _its_ `depends_on` target
-            target = abs_ref(at_rel.name)
-            if (depends_on := self.nx.get(at_rel.name)) is not None:
-                if (t := depends_on.get('depends_on')) is not None:
-                    # the relative target has a dependency, so we chain off of that:
-                    if isinstance(t, NXfield):
-                        # TODO what if this isn't a string?
-                        t = str(t)
-                    if t.startswith('/'):
-                        target = t
-                    elif t == '.':
-                        target = None
-                    else:
-                        target = f'{target}/{t}'
-                else:
-                    # the relative target exists but has no dependency, so is absolute
-                    target = None
-            else:
-                raise RuntimeError('transformations defined out of order')
-            trans.extend(nx_parts.transformations(inst.name, target))
+            trans.extend(nx_parts.position_transformations(inst.name, target))
+            if at_rel != rot_rel:
+                a_ori = NXOrient(self, at_rel.orientation - self.origin)
+                trans.extend(a_ori.rotation_inverse_transformations(inst.name, last_ref(trans, target)))
+                if rot_rel is not None:
+                    target = self.resolve_target(rot_rel)  # fallback in case trans empty
+                    b_ori = NXOrient(self, rot_rel.orientation - self.origin)
+                    trans.extend(b_ori.rotation_transformations(rot_rel.name, last_ref(trans, target)))
+            trans.extend(nx_parts.rotation_transformations(inst.name, last_ref(trans, target)))
+            if not trans and target is not None:
+                trans = [(target, NXfield())]
 
         return {k: v for k, v in trans}
 

--- a/src/moreniius/mccode/instr.py
+++ b/src/moreniius/mccode/instr.py
@@ -136,8 +136,8 @@ class NXInstr:
         if any_abs or at_rel != rot_rel:
             import warnings
             warnings.warn(
-                "All mixed-reference-type orientations untested."
-                "Only 'AT (x, y, z) ABSOLUTE ROTATE (a, b, c) REF' might work"
+                "All mixed-reference-type orientations untested. "
+                "Only 'AT (x, y, z) ABSOLUTE ROTATED (a, b, c) REF' might work\n"
             )
         at_vec = Vector(*at_vec) if isinstance(at_vec, tuple) else at_vec
         rot_vec = Angles(*rot_vec) if isinstance(rot_vec, tuple) else rot_vec
@@ -152,13 +152,16 @@ class NXInstr:
             nx_parts = NXParts(self, rot, rot)
             trans.extend(nx_parts.rotation_transformations(inst.name, last_ref(trans)))
         elif rot_rel is None:
+            at_name = at_rel.name if isinstance(at_rel, Instance) else at_rel
             raise RuntimeError(
-                "'AT (x, y, z) RELATIVE comp ROTATE (a, b, c) ABSOLUTE'"
+                f"'COMPONENT {inst.name} ... AT {at_vec} RELATIVE {at_name} ROTATED {rot_vec} ABSOLUTE'"
                 " not yet implemented"
             )
         elif at_rel != rot_rel:
+            at_name = at_rel.name if isinstance(at_rel, Instance) else at_rel
+            rot_name = rot_rel.name if isinstance(rot_rel, Instance) else rot_rel
             raise RuntimeError(
-                "'AT (x, y, z) RELATIVE comp1 ROTATE (a, b, c) RELATIVE comp2'"
+                f"'COMPONENT {inst.name} ... AT {at_vec} RELATIVE {at_name} ROTATED {rot_vec} RELATIVE {rot_name}'"
                 " not yet implemented"
             )
         else:

--- a/src/moreniius/mccode/orientation.py
+++ b/src/moreniius/mccode/orientation.py
@@ -54,6 +54,19 @@ class NXPart:
         # handle the case where angle is not a constant?
         return self.make_nx(NXfield, angle, vector=axis, depends_on=dep, transformation_type='rotation', units=angle_unit)
 
+    def rotation_inverse(self, dep: str) -> NXfield:
+        from mccode_antlr.instr import TranslationPart
+        if isinstance(self.o, TranslationPart):
+            raise RuntimeError('Part is a translation')
+        try:
+            axis, angle, angle_unit = self.o.rotation_axis_angle
+        except RuntimeError as error:
+            log.error(f'Failed to get rotation axis and angle: {error}')
+            print(repr(self.o))
+            raise NotImplementedError()
+        return self.make_nx(NXfield, angle, vector=[-v for v in axis], depends_on=dep,
+                            transformation_type='rotation', units=angle_unit)
+
     def transformations(self, name: str, dep: str | None = None) -> list[tuple[str, NXfield]]:
         if self.o.is_translation and self.o.is_rotation:
             ops = self.translations(dep, name)
@@ -90,6 +103,15 @@ class NXParts:
         dep = dep or '.'
         return self._transformations(name, dep, 'r', self.rotation.stack())
 
+    def rotation_inverse_transformations(self, name: str, dep: str | None = None) -> list[tuple[str, NXfield]]:
+        dep = dep or '.'
+        nx_transformations = []
+        for i, op in enumerate(reversed(list(self.rotation.stack()))):
+            entry = (f'{name}_ri{i}', NXPart(self.instr, op).rotation_inverse(dep))
+            nx_transformations.append(entry)
+            dep = entry[0]
+        return nx_transformations
+
     def transformations(self, name: str, dep: str | None = None) -> list[tuple[str, NXfield]]:
         parts = self.position_transformations(name, dep=dep)
         # If there were any positioning transformations, we need to update
@@ -125,5 +147,8 @@ class NXOrient:
 
     def rotation_transformations(self, name: str, dep: str | None = None) -> list[tuple[str, NXfield]]:
         return self.nx_parts.rotation_transformations(name, dep)
+
+    def rotation_inverse_transformations(self, name: str, dep: str | None = None) -> list[tuple[str, NXfield]]:
+        return self.nx_parts.rotation_inverse_transformations(name, dep)
 
 


### PR DESCRIPTION
This pull request introduces improved handling for relative and mixed-reference transformations in the instrument orientation logic. The main changes add support for inverse rotation transformations, refactor how dependency targets are resolved, and clean up the transformation pipeline for better correctness and maintainability. Closes #47 

### Transformation logic improvements

* Added a new method `rotation_inverse` to `NXOrient` for constructing inverse rotation transformations, and corresponding `rotation_inverse_transformations` methods to both `NXOrient` and `NXParts` to generate the correct transformation sequences. [[1]](diffhunk://#diff-6597c6e92893c6faabc647c560d386f045f78b8e0d936cf131008fd77e19b3c4R57-R69) [[2]](diffhunk://#diff-6597c6e92893c6faabc647c560d386f045f78b8e0d936cf131008fd77e19b3c4R106-R114) [[3]](diffhunk://#diff-6597c6e92893c6faabc647c560d386f045f78b8e0d936cf131008fd77e19b3c4R151-R153)
* Refactored the transformation pipeline in `make_transformations` to handle cases where the position and rotation references differ, including chaining inverse and direct rotations as appropriate.

### Dependency resolution improvements

* Introduced the `resolve_target` method to centralize and clarify the resolution of `depends_on` targets for transformation chains, replacing ad-hoc logic and improving error handling for out-of-order definitions.

### Refactoring and cleanup

* Simplified and clarified the logic for determining the last dependency reference (`last_ref`), and removed deprecated or redundant code paths in the transformation construction.