### PR TITLE
Refactor to use mccode_antlr.instr.orientation.Orient via Instr

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "moreniius"
 dependencies = [
     'zenlog>=1.1',
     'platformdirs>=3.11',
-    "mccode-antlr[hdf5]<0.21.0",
+    "mccode-antlr>=0.21.0",
     'nexusformat>=2.0.0',
     'networkx',
 ]

--- a/src/moreniius/additions.py
+++ b/src/moreniius/additions.py
@@ -24,7 +24,8 @@ def readout_translator(instance):
     from .utils import ev44_event_data_group
     stream = ev44_event_data_group(source='caen', topic=BIFROST_DETECTOR_TOPIC)
 
-    readout_pos, readout_rot = instance.obj.orientation.position_parts(), instance.obj.orientation.rotation_parts()
+    readout_orient = instance.instr.orientations[instance.obj.name]
+    readout_pos, readout_rot = readout_orient.position_parts(), readout_orient.rotation_parts()
 
     counts = [geometry.detector_number.size for _, _, geometry in BIFROST_DETECTOR_MODULES.values()]
     total = sum(counts)
@@ -337,7 +338,8 @@ def bifrost_detector_collector(self):
     # nx_obj = detector_tubes_only_cylinder(self)  # each pixel is a cylinder
     nx_obj = detector_tubes_offsets_and_one_cylinder(self)  # all pixels share one cylinder
     # stash the object parts
-    pos, rot = self.obj.orientation.position_parts(), self.obj.orientation.rotation_parts()
+    orient = self.instr.orientations[self.obj.name]
+    pos, rot = orient.position_parts(), orient.rotation_parts()
     BIFROST_DETECTOR_MODULES[str(self.obj.when)] = pos, rot, nx_obj.geometry
     # and return it
     return nx_obj

--- a/src/moreniius/mccode/instr.py
+++ b/src/moreniius/mccode/instr.py
@@ -19,6 +19,7 @@ class NXInstr:
     only_nx: bool = field(default=False)
     forward_graph: Union[DiGraph, None] = None
     reverse_graph: Union[DiGraph, None] = None
+    orientations: dict = field(default_factory=dict)
 
     def __post_init__(self):
         """Start the C translation to ensure McCode-oddities are handled before any C-code parsing."""
@@ -56,6 +57,8 @@ class NXInstr:
 
         self.declared = variables
         #
+        if not self.orientations:
+            self.orientations = self.instr.resolve_orientations()
         if self.origin is None:
             self.guess_origin()
             assert self.origin is not None
@@ -91,7 +94,7 @@ class NXInstr:
             )
         if possible:
             self.origin_name = possible[0].name
-            self.origin = possible[0].orientation
+            self.origin = self.orientations[possible[0].name]
         else:
             self.origin = Orient()
 
@@ -141,11 +144,11 @@ class NXInstr:
         at_vec = Vector(*at_vec) if isinstance(at_vec, tuple) else at_vec
         rot_vec = Angles(*rot_vec) if isinstance(rot_vec, tuple) else rot_vec
         if at_rel is None:
-            nx_ori = NXOrient(self, inst.orientation - self.origin)
+            nx_ori = NXOrient(self, self.orientations[inst.name] - self.origin)
             if rot_rel is None:
                 return nx_ori.transformations(inst.name)
             trans.extend(nx_ori.position_transformations(inst.name))
-            rel_ori = NXOrient(self, rot_rel.orientation - self.origin)
+            rel_ori = NXOrient(self, self.orientations[rot_rel.name] - self.origin)
             trans.extend(rel_ori.rotation_transformations(rot_rel.name, last_ref(trans)))
             rot = Parts(Parts.from_at_rotated(Vector(), rot_vec, True).stack()).reduce()
             nx_parts = NXParts(self, rot, rot)
@@ -157,11 +160,11 @@ class NXInstr:
             nx_parts = NXParts(self, at_parts, rot_parts)
             trans.extend(nx_parts.position_transformations(inst.name, target))
             if at_rel != rot_rel:
-                a_ori = NXOrient(self, at_rel.orientation - self.origin)
+                a_ori = NXOrient(self, self.orientations[at_rel.name] - self.origin)
                 trans.extend(a_ori.rotation_inverse_transformations(inst.name, last_ref(trans, target)))
                 if rot_rel is not None:
                     target = self.resolve_target(rot_rel)  # fallback in case trans empty
-                    b_ori = NXOrient(self, rot_rel.orientation - self.origin)
+                    b_ori = NXOrient(self, self.orientations[rot_rel.name] - self.origin)
                     trans.extend(b_ori.rotation_transformations(rot_rel.name, last_ref(trans, target)))
             trans.extend(nx_parts.rotation_transformations(inst.name, last_ref(trans, target)))
             if not trans and target is not None:

--- a/src/moreniius/nexus_structure.py
+++ b/src/moreniius/nexus_structure.py
@@ -19,8 +19,11 @@ def load_instr(filepath: str | Path) -> Instr:
     elif filepath.suffix.lower() == '.json':
         from mccode_antlr.io.json import load_json
         return load_json(filepath)
+    elif filepath.suffix.lower() in ('.msgpack', '.mpk'):
+        from mccode_antlr.io.msgpack import load_msgpack
+        return load_msgpack(filepath)
 
-    from mccode_antlr.io import load_hdf5
+    from mccode_antlr.io import load_hdf5  # deprecated since mccode-antlr 0.20.2
     return load_hdf5(filepath)
 
 


### PR DESCRIPTION
This pull request updates how component orientations are managed and accessed throughout the codebase, moving from direct use of the `orientation` attribute to a centralized `orientations` dictionary in the `NXInstr` class. This change ensures more consistent and robust handling of orientations, especially when resolving relationships between components. Additionally, support for loading `.msgpack`/`.mpk` files is added, and the minimum version of `mccode-antlr` is updated.

**Orientation Handling Refactor:**

* Added an `orientations` dictionary to the `NXInstr` class for centralized orientation management.
* Replaced all direct accesses to `obj.orientation` with lookups in the `orientations` dictionary, ensuring consistent orientation retrieval in `additions.py` and `instr.py`. [[1]](diffhunk://#diff-f3811d5258d05dd60bb3856af1a8cde7cdcef1d5c1eba546579990a171f2198bL27-R28) [[2]](diffhunk://#diff-f3811d5258d05dd60bb3856af1a8cde7cdcef1d5c1eba546579990a171f2198bL340-R342) [[3]](diffhunk://#diff-065eb9b1937a439d5a116ccaf188ae46da25cf7737588d0d69d2ea28d252807aL94-R97) [[4]](diffhunk://#diff-065eb9b1937a439d5a116ccaf188ae46da25cf7737588d0d69d2ea28d252807aL144-R151) [[5]](diffhunk://#diff-065eb9b1937a439d5a116ccaf188ae46da25cf7737588d0d69d2ea28d252807aL160-R167)
* Ensured `orientations` is populated during initialization by resolving orientations if not already set.

**File Loading Improvements:**

* Added support for loading instrument files in `.msgpack` and `.mpk` formats in `load_instr`.

**Dependency Update:**

* Updated the `mccode-antlr` dependency to require version `>=0.21.0` in `pyproject.toml`.